### PR TITLE
Fix start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # arextron.github.io
+
+## Development
+
+Install dependencies and start the API locally with:
+
+```bash
+npm install
+npm start
+```
+
+This runs `node api/index.js`, which exports an Express app for Vercel.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "start": "node server.js"
+    "start": "node api/index.js"
   },
   "dependencies": {
     "axios": "^1.10.0",


### PR DESCRIPTION
## Summary
- fix the start script path
- document how to run the API locally

## Testing
- `npm install`
- `node api/index.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853bd57a014832ba0474b8271d4e3b2